### PR TITLE
Change Time library include filename to TimeLib.h

### DIFF
--- a/examples/PowerOutageLogger/PowerOutageLogger.pde
+++ b/examples/PowerOutageLogger/PowerOutageLogger.pde
@@ -15,7 +15,7 @@
  
 #include <MCP79412RTC.h>          //http://github.com/JChristensen/MCP79412RTC
 #include <Streaming.h>            //http://arduiniana.org/libraries/streaming/
-#include <Time.h>                 //http://www.arduino.cc/playground/Code/Time  
+#include <TimeLib.h>              //http://www.arduino.cc/playground/Code/Time  
 #include <Timezone.h>             //http://github.com/JChristensen/Timezone
 #include <Wire.h>                 //http://arduino.cc/en/Reference/Wire (included with Arduino IDE)
 

--- a/examples/SetSerial/SetSerial.ino
+++ b/examples/SetSerial/SetSerial.ino
@@ -36,7 +36,7 @@
  
 #include <MCP79412RTC.h>      //http://github.com/JChristensen/MCP79412RTC
 #include <Streaming.h>        //http://arduiniana.org/libraries/streaming/
-#include <Time.h>             //http://playground.arduino.cc/Code/Time
+#include <TimeLib.h>          //http://playground.arduino.cc/Code/Time
 #include <Wire.h>             //http://arduino.cc/en/Reference/Wire
 
 void setup(void)

--- a/examples/TimeRTC/TimeRTC.pde
+++ b/examples/TimeRTC/TimeRTC.pde
@@ -5,7 +5,7 @@
  * only the #include statement has been changed to include the MCP79412RTC library.
  */
 
-#include <Time.h>  
+#include <TimeLib.h>  
 #include <Wire.h>  
 #include <MCP79412RTC.h>  //http://github.com/JChristensen/MCP79412RTC
 

--- a/examples/rtcSet1/rtcSet1.pde
+++ b/examples/rtcSet1/rtcSet1.pde
@@ -15,7 +15,7 @@
  *----------------------------------------------------------------------*/
  
 #include <MCP79412RTC.h>    //http://github.com/JChristensen/MCP79412RTC
-#include <Time.h>           //http://www.arduino.cc/playground/Code/Time  
+#include <TimeLib.h>        //http://www.arduino.cc/playground/Code/Time  
 #include <Wire.h>           //http://arduino.cc/en/Reference/Wire (included with Arduino IDE)
 
 void setup(void)

--- a/examples/rtcSet2/rtcSet2.pde
+++ b/examples/rtcSet2/rtcSet2.pde
@@ -19,7 +19,7 @@
  *----------------------------------------------------------------------*/
  
 #include <MCP79412RTC.h>    //http://github.com/JChristensen/MCP79412RTC
-#include <Time.h>           //http://www.arduino.cc/playground/Code/Time  
+#include <TimeLib.h>        //http://www.arduino.cc/playground/Code/Time  
 #include <Wire.h>           //http://arduino.cc/en/Reference/Wire (included with Arduino IDE)
 
 tmElements_t tm;

--- a/examples/rtcSet3/rtcSet3.pde
+++ b/examples/rtcSet3/rtcSet3.pde
@@ -14,7 +14,7 @@
  *----------------------------------------------------------------------*/
  
 #include <MCP79412RTC.h>    //http://github.com/JChristensen/MCP79412RTC
-#include <Time.h>           //http://www.arduino.cc/playground/Code/Time  
+#include <TimeLib.h>        //http://www.arduino.cc/playground/Code/Time  
 #include <Wire.h>           //http://arduino.cc/en/Reference/Wire (included with Arduino IDE)
 
 void setup(void)

--- a/examples/rtcSetSerial/rtcSetSerial.pde
+++ b/examples/rtcSetSerial/rtcSetSerial.pde
@@ -13,7 +13,7 @@
  *----------------------------------------------------------------------*/
 
 #include <MCP79412RTC.h>        //http://github.com/JChristensen/MCP79412RTC
-#include <Time.h>               //http://www.arduino.cc/playground/Code/Time  
+#include <TimeLib.h>            //http://www.arduino.cc/playground/Code/Time  
 #include <Wire.h>               //http://arduino.cc/en/Reference/Wire (included with Arduino IDE)
 
 #define PRINT_INTERVAL 1000     //ms between printing the time

--- a/examples/tiny79412_KnockBang/tiny79412_KnockBang.ino
+++ b/examples/tiny79412_KnockBang/tiny79412_KnockBang.ino
@@ -22,7 +22,7 @@
  *----------------------------------------------------------------------*/ 
 
 #include <MCP79412RTC.h>           //http://github.com/JChristensen/MCP79412RTC
-#include <Time.h>                  //http://playground.arduino.cc/Code/Time
+#include <TimeLib.h>               //http://playground.arduino.cc/Code/Time
 #include <TinyDebugKnockBang.h>    //http://code.google.com/p/arduino-tiny/
 #include <TinyWireM.h>             //http://playground.arduino.cc/Code/USIi2c
 

--- a/src/MCP79412RTC.h
+++ b/src/MCP79412RTC.h
@@ -23,7 +23,7 @@
 
 #ifndef MCP79412RTC_h
 #define MCP79412RTC_h
-#include <Time.h>
+#include <TimeLib.h>
 
 #if defined(ARDUINO) && ARDUINO >= 100
 #include <Arduino.h>


### PR DESCRIPTION
The new version of avr-libc included with Arduino IDE 1.6.10/Arduino AVR
Boards 1.6.12 and later has a file named time.h. This causes that file
to be included instead of the intended file on case insensitive
operating systems, resulting in compile failure. This is also an issue
with non-AVR boards. Recent versions of the Time library have a file
named TimeLib.h to solve this issue.
