### PR TITLE
Platformio.org and TraviCI support/integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+python:
+    - "2.7"
+
+# Cache PlatformIO packages using Travis CI container-based infrastructure
+sudo: false
+cache:
+    directories:
+        - "~/.platformio"
+
+env:
+    - PLATFORMIO_CI_SRC=examples/TimeRTC/
+    - PLATFORMIO_CI_SRC=examples/rtcSetSerial/
+    - PLATFORMIO_CI_SRC=examples/rtcSet1
+    - PLATFORMIO_CI_SRC=examples/rtcSet2
+    - PLATFORMIO_CI_SRC=examples/rtcSet3
+
+install:
+    - pip install -U platformio
+
+script:
+    - platformio ci --lib=. --board=moteino --board uno --board=moteinomega

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/JChristensen/MCP79412RTC.svg?branch=master)](https://travis-ci.org/JChristensen/MCP79412RTC)
 # Arduino MCP79412 RTC Library v1.0 #
 https://github.com/JChristensen/MCP79412RTC  
 ReadMe file  

--- a/library.json
+++ b/library.json
@@ -1,0 +1,12 @@
+{
+  "name": "MCP79412RTC",
+  "keywords": "RTC, i2c",
+  "description": "RTC Library for Maxim MCP79412 chip",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/JChristensen/MCP79412RTC"
+  },
+  "frameworks": "Arduino",
+  "platforms": "atmelavr"
+}

--- a/library.json
+++ b/library.json
@@ -1,7 +1,7 @@
 {
   "name": "MCP79412RTC",
   "keywords": "RTC, i2c",
-  "description": "RTC Library for Maxim MCP79412 chip",
+  "description": "RTC Library for Microchip MCP79412 chip",
   "repository":
   {
     "type": "git",

--- a/library.json
+++ b/library.json
@@ -7,6 +7,12 @@
     "type": "git",
     "url": "https://github.com/JChristensen/MCP79412RTC"
   },
+  "dependencies":
+  {
+    "name": "Time",
+    "authors": "Paul Stoffregen",
+    "frameworks": "arduino"
+  },
   "frameworks": "Arduino",
   "platforms": "atmelavr"
 }


### PR DESCRIPTION
This adds library.json manifest so Platformio can crawler and add this
library to the library registry. Also adds .travis.yml to run automatic
build (using platformio) as a continuos integration support.

Please enable Travis.CI for this project
http://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A
(steps 1, 2, 5)

Signed-off-by: Josenivaldo Benito Jr <jrbenito@benito.qsl.br>